### PR TITLE
Rubocop Configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+AllCops:
+  Exclude:
+    - "spec/**/*"
+    - "node_modules/**/*"
+    - "db/**/*"
+    - "bin/**/*"
+    - "lib/**/*"
+    - "config/environments/*"
+    - "config/initializers/*"
+    - "config/puma.rb"
+    - "config/application.rb"


### PR DESCRIPTION
Configure rubocop to ignore
```
    - "spec/**/*"
    - "node_modules/**/*"
    - "db/**/*"
    - "bin/**/*"
    - "lib/**/*"
    - "config/environments/*"
    - "config/initializers/*"
    - "config/puma.rb"
    - "config/application.rb"
```