### PR TITLE
Sad path for new tutorial

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -4,10 +4,15 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
-    tutorial = Tutorial.create!(tutorial_params)
-    flash[:success] = 'Successfully created tutorial.'
-    redirect_to tutorial_path(tutorial.id)
-  end
+    tutorial = Tutorial.create(tutorial_params)
+    if tutorial.save
+      flash[:success] = 'Successfully created tutorial.'
+      redirect_to tutorial_path(tutorial.id)
+    else 
+      flash[:error] = 'Tutorial was not created.'
+      redirect_to new_admin_tutorial_path
+    end
+  enda
 
   def new
     @tutorial = Tutorial.new

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,4 +1,7 @@
 class Tutorial < ApplicationRecord
+  validates_presence_of :title
+  validates_presence_of :description
+  validates_presence_of :thumbnail
   has_many :videos, ->  { order(position: :ASC) }
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos

--- a/app/views/admin/tutorials/new.html.erb
+++ b/app/views/admin/tutorials/new.html.erb
@@ -1,5 +1,5 @@
 <h2>New Tutorial</h2>
-<%= form_for [:admin, @tutorial] do |f| %>
+<%= form_for [:admin, Tutorial.new] do |f| %>
   <%= f.label :title %>
   <%= f.text_field :title, class: "block col-4 field" %>
   <%= f.label :description %>

--- a/spec/features/admin/new_tutorial_spec.rb
+++ b/spec/features/admin/new_tutorial_spec.rb
@@ -25,4 +25,18 @@ describe 'An admin can create a new tutorial' do
 
     expect(page).to have_content('Successfully created tutorial.')
   end
+
+  it 'will receive a flash message if not created' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit new_admin_tutorial_path
+
+    fill_in 'tutorial[title]', with: "How to do Rails"
+    fill_in 'tutorial[description]', with: "Here is a video description."
+
+    click_on "Save"
+    expect(current_path).to eq(new_admin_tutorial_path)
+
+    expect(page).to have_content('Tutorial was not created.')
+  end
 end


### PR DESCRIPTION
Add error message when an admin is creating a new tutorial and it is not created successfully.